### PR TITLE
 Bug/99731 - Na lista de itens na montagem dos blocos está sendo exibido todas as versões após salvar a edição pelo simulador

### DIFF
--- a/src/SME.Simulador.Prova.Serap.Aplicacao/UseCases/GerarNovaVersaoQuestaoUseCase.cs
+++ b/src/SME.Simulador.Prova.Serap.Aplicacao/UseCases/GerarNovaVersaoQuestaoUseCase.cs
@@ -31,9 +31,7 @@ public class GerarNovaVersaoQuestaoUseCase : AbstractUseCase, IGerarNovaVersaoQu
             {
                 var textoBaseId = await TrataTextoBase(request, questaoAtual, textoBaseQuestao);
 
-                bool ehUltimaVersao = questaoAtual.UltimaVersao != null ? (bool)questaoAtual.UltimaVersao : true;
-                if (!ehUltimaVersao)
-                    await mediator.Send(new DesabilitarUltimaVersaoQuestaoPorCodigoCommand(questaoAtual.CodigoItem));
+                await mediator.Send(new DesabilitarUltimaVersaoQuestaoPorCodigoCommand(questaoAtual.CodigoItem));
 
                 var novaVersaoQuestaoId = await TrataQuestaoNovaVersao(request, questaoAtual, textoBaseId);
 


### PR DESCRIPTION
[AB#99731](https://dev.azure.com/amcomgov/c9b99f20-3b4d-464b-a2eb-69d1f704e9d3/_workitems/edit/99731)